### PR TITLE
Guard against relative/absolute URI

### DIFF
--- a/src/Guardian.Net35/GuardExtensions.cs
+++ b/src/Guardian.Net35/GuardExtensions.cs
@@ -347,6 +347,12 @@ internal static class GuardExtensions
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
     public static void NullOrRelative(this Guard guard, Func<Uri> expression)
     {
+        Guard.Against.Null(expression);
+
+        if (!expression().IsAbsoluteUri)
+        {
+            throw new ArgumentException("Value cannot be a relative URI.", Guard.Expression.Parse(expression));
+        }
     }
 
     /// <summary>
@@ -359,6 +365,12 @@ internal static class GuardExtensions
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
     public static void NullOrAbsolute(this Guard guard, Func<Uri> expression)
     {
+        Guard.Against.Null(expression);
+
+        if (expression().IsAbsoluteUri)
+        {
+            throw new ArgumentException("Value cannot be an absolute URI.", Guard.Expression.Parse(expression));
+        }
     }
 
     [DebuggerStepThrough]

--- a/src/Guardian.Net35/GuardExtensions.cs
+++ b/src/Guardian.Net35/GuardExtensions.cs
@@ -337,6 +337,30 @@ internal static class GuardExtensions
         Guard.Against.OutOfRange(expression, value => value <= 0, "Value cannot be negative or zero.");
     }
 
+    /// <summary>
+    /// Guard against null or relative URI values.
+    /// </summary>
+    /// <param name="guard">The guard clause.</param>
+    /// <param name="expression">An expression returning the value to guard against.</param>
+    [DebuggerStepThrough]
+    [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
+    public static void NullOrRelative(this Guard guard, Func<Uri> expression)
+    {
+    }
+
+    /// <summary>
+    /// Guard against null or absolute URI values.
+    /// </summary>
+    /// <param name="guard">The guard clause.</param>
+    /// <param name="expression">An expression returning the value to guard against.</param>
+    [DebuggerStepThrough]
+    [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
+    public static void NullOrAbsolute(this Guard guard, Func<Uri> expression)
+    {
+    }
+
     [DebuggerStepThrough]
     [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]

--- a/src/Guardian.Net40/GuardExtensions.cs
+++ b/src/Guardian.Net40/GuardExtensions.cs
@@ -348,6 +348,12 @@ internal static class GuardExtensions
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
     public static void NullOrRelative(this Guard guard, Func<Uri> expression)
     {
+        Guard.Against.Null(expression);
+
+        if (!expression().IsAbsoluteUri)
+        {
+            throw new ArgumentException("Value cannot be a relative URI.", Guard.Expression.Parse(expression));
+        }
     }
 
     /// <summary>
@@ -360,6 +366,12 @@ internal static class GuardExtensions
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
     public static void NullOrAbsolute(this Guard guard, Func<Uri> expression)
     {
+        Guard.Against.Null(expression);
+
+        if (expression().IsAbsoluteUri)
+        {
+            throw new ArgumentException("Value cannot be an absolute URI.", Guard.Expression.Parse(expression));
+        }
     }
 
     [DebuggerStepThrough]

--- a/src/Guardian.Net40/GuardExtensions.cs
+++ b/src/Guardian.Net40/GuardExtensions.cs
@@ -338,6 +338,30 @@ internal static class GuardExtensions
         Guard.Against.OutOfRange(expression, value => value <= 0, "Value cannot be negative or zero.");
     }
 
+    /// <summary>
+    /// Guard against null or relative URI values.
+    /// </summary>
+    /// <param name="guard">The guard clause.</param>
+    /// <param name="expression">An expression returning the value to guard against.</param>
+    [DebuggerStepThrough]
+    [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
+    public static void NullOrRelative(this Guard guard, Func<Uri> expression)
+    {
+    }
+
+    /// <summary>
+    /// Guard against null or absolute URI values.
+    /// </summary>
+    /// <param name="guard">The guard clause.</param>
+    /// <param name="expression">An expression returning the value to guard against.</param>
+    [DebuggerStepThrough]
+    [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
+    public static void NullOrAbsolute(this Guard guard, Func<Uri> expression)
+    {
+    }
+
     [DebuggerStepThrough]
     [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]

--- a/src/Guardian.Net45/GuardExtensions.cs
+++ b/src/Guardian.Net45/GuardExtensions.cs
@@ -368,6 +368,12 @@ internal static class GuardExtensions
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
     public static void NullOrRelative(this Guard guard, Func<Uri> expression)
     {
+        Guard.Against.Null(expression);
+
+        if (!expression().IsAbsoluteUri)
+        {
+            throw new ArgumentException("Value cannot be a relative URI.", Guard.Expression.Parse(expression));
+        }
     }
 
     /// <summary>
@@ -381,6 +387,12 @@ internal static class GuardExtensions
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
     public static void NullOrAbsolute(this Guard guard, Func<Uri> expression)
     {
+        Guard.Against.Null(expression);
+
+        if (expression().IsAbsoluteUri)
+        {
+            throw new ArgumentException("Value cannot be an absolute URI.", Guard.Expression.Parse(expression));
+        }
     }
 
     [DebuggerStepThrough]

--- a/src/Guardian.Net45/GuardExtensions.cs
+++ b/src/Guardian.Net45/GuardExtensions.cs
@@ -357,6 +357,32 @@ internal static class GuardExtensions
         Guard.Against.OutOfRange(expression, value => value <= 0, "Value cannot be negative or zero.");
     }
 
+    /// <summary>
+    /// Guard against null or relative URI values.
+    /// </summary>
+    /// <param name="guard">The guard clause.</param>
+    /// <param name="expression">An expression returning the value to guard against.</param>
+    [DebuggerStepThrough]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
+    public static void NullOrRelative(this Guard guard, Func<Uri> expression)
+    {
+    }
+
+    /// <summary>
+    /// Guard against null or absolute URI values.
+    /// </summary>
+    /// <param name="guard">The guard clause.</param>
+    /// <param name="expression">An expression returning the value to guard against.</param>
+    [DebuggerStepThrough]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "guard", Justification = "By design.")]
+    public static void NullOrAbsolute(this Guard guard, Func<Uri> expression)
+    {
+    }
+
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "May not be called.")]

--- a/src/tests/Guardian.Net35.Debug.Tests/Extensions/ExceptionExtensions.cs
+++ b/src/tests/Guardian.Net35.Debug.Tests/Extensions/ExceptionExtensions.cs
@@ -14,7 +14,9 @@ namespace Guardian.Tests.Extensions
         Negative,
         NegativeOrZero,
         Positive,
-        PositiveOrZero
+        PositiveOrZero,
+        RelativeUri,
+        AbsoluteUri
     }
 
     internal static class ExceptionExtensions
@@ -46,13 +48,42 @@ namespace Guardian.Tests.Extensions
                     case ExceptionType.PositiveOrZero:
                         expectedMessage = "Value cannot be positive or zero.";
                         break;
+
+                    default:
+                        expectedMessage = "Should not get here: debug test";
+                        break;
                 }
 
                 exception.Message.Should().StartWith(expectedMessage);
             }
             else if (typeof(ArgumentException).IsAssignableFrom(typeof(T)))
             {
-                exception.Message.Should().StartWith(type == ExceptionType.Null ? "Value cannot be null." : "Value cannot be empty.");
+                var expectedMessage = default(string);
+
+                switch (type)
+                {
+                    case ExceptionType.Null:
+                        expectedMessage = "Value cannot be null.";
+                        break;
+
+                    case ExceptionType.Empty:
+                        expectedMessage = "Value cannot be empty.";
+                        break;
+
+                    case ExceptionType.RelativeUri:
+                        expectedMessage = "Value cannot be a relative URI.";
+                        break;
+
+                    case ExceptionType.AbsoluteUri:
+                        expectedMessage = "Value cannot be an absolute URI.";
+                        break;
+
+                    default:
+                        expectedMessage = "Should not get here: debug test";
+                        break;
+                }
+
+                exception.Message.Should().StartWith(expectedMessage);
             }
 
             if (typeof(NotSupportedException).IsAssignableFrom(typeof(T)))

--- a/src/tests/Guardian.Net35.Debug.Tests/GuardExtensionsTests.cs
+++ b/src/tests/Guardian.Net35.Debug.Tests/GuardExtensionsTests.cs
@@ -204,5 +204,83 @@ namespace Guardian.Tests
             // assert
             exception.Should().BeNull();
         }
+
+        [Fact]
+        public void NullUriRelative()
+        {
+            // arrange
+            var uri = (Uri)null;
+
+            // act
+            var exception = Record.Exception(() => Guard.Against.NullOrRelative(() => uri));
+
+            // assert
+            exception.ShouldBeValid<ArgumentNullException>().WithParameter("uri");
+        }
+
+        [Fact]
+        public void RelativeUri()
+        {
+            // arrange
+            var uri = new Uri(@"subdirectory/resource.html", UriKind.Relative);
+
+            // act
+            var exception = Record.Exception(() => Guard.Against.NullOrRelative(() => uri));
+
+            // assert
+            exception.ShouldBeValid<ArgumentException>(ExceptionType.RelativeUri).WithParameter("uri");
+        }
+
+        [Fact]
+        public void ValidAbsoluteUri()
+        {
+            // arrange
+            var uri = new Uri(@"http://www.test.com/");
+
+            // act
+            var exception = Record.Exception(() => Guard.Against.NullOrRelative(() => uri));
+
+            // assert
+            exception.Should().BeNull();
+        }
+
+        [Fact]
+        public void NullUriAbsolute()
+        {
+            // arrange
+            var uri = (Uri)null;
+
+            // act
+            var exception = Record.Exception(() => Guard.Against.NullOrAbsolute(() => uri));
+
+            // assert
+            exception.ShouldBeValid<ArgumentNullException>().WithParameter("uri");
+        }
+
+        [Fact]
+        public void AbsoluteUri()
+        {
+            // arrange
+            var uri = new Uri(@"http://www.test.com/");
+
+            // act
+            var exception = Record.Exception(() => Guard.Against.NullOrAbsolute(() => uri));
+
+            // assert
+            exception.ShouldBeValid<ArgumentException>(ExceptionType.AbsoluteUri).WithParameter("uri");
+        }
+
+        [Fact]
+        public void ValidRelativeUri()
+        {
+            // arrange
+            var uri = new Uri(@"subdirectory/resource.html", UriKind.Relative);
+
+            // act
+            var exception = Record.Exception(() => Guard.Against.NullOrAbsolute(() => uri));
+
+            // assert
+            exception.Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
Added extension methods `Guard.Against.NullOrRelative` and `Guard.Against.NullOrAbsolute` to the Guardian Extensions

Resolves #57
